### PR TITLE
Alerta de descrição truncada ao gerar URL automática de PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ gromit push --force --show-diff
 # Cole a URL no navegador para criar o PR automaticamente:
 # https://github.com/user/repo/compare/master...feature/auth?quick_pull=1&title=...
 #
+# Se a descrição for muito longa (>800 caracteres):
+# ⚠️  DESCRIÇÃO TRUNCADA NA URL
+# 1. Abra a URL no navegador (título e parte da descrição preenchidos)
+# 2. Cole a descrição completa mostrada no terminal
+#
 # 💡 Para apenas análise: gromit analyze --push
 ```
 


### PR DESCRIPTION
#### Cenário
Ao utilizar o comando de push para criar Pull Requests automáticos, o sistema gera uma URL pré-preenchida com o título e a descrição do PR. Em casos de descrições muito longas, parte do conteúdo pode ser truncada devido a limitações de tamanho da URL.
#### Problema
Usuários não eram alertados quando a descrição do PR excedia o limite suportado pela URL